### PR TITLE
52738-arabic-locale-issues

### DIFF
--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -9,5 +9,5 @@ export const ChartIQLanguages = {
   HU: { title: 'Hungarian', code: 'hu-HU' },
   ZH: { title: 'Chinese', code: 'zh-CN' },
   JA: { title: 'Japanese', code: 'ja-JP' },
-  AR: { title: 'Arabic', code: 'ar-EG' },
+  AR: { title: 'Arabic', code: 'ar-EG-u-nu-latn' },
 };


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/15/cards/52738/details/

Change the locale from 'ar-EG' to 'ar-EG-u-nu-latn' to address the x-axis date format issues and the y-axis number display for Arabic

