### PR TITLE
53000 - gracefully manage ChartIQView destruction

### DIFF
--- a/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
@@ -43,8 +43,12 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
     if (data != null) {
       val handler = Handler(Looper.getMainLooper())
       handler.post(Runnable {
+        if (!chartIQViewModel.isChartInitialized()) {
+          return@Runnable
+        }
         chartIQViewModel.initialCallbacks.find { it.id == id }?.let {
           it.callback.execute(data.toOHCLList())
+          chartIQViewModel.initialCallbacks.removeAll { callback -> callback.id == id }
         }
       })
     }
@@ -55,8 +59,12 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
     if (data != null) {
       val handler = Handler(Looper.getMainLooper())
       handler.post(Runnable {
+        if (!chartIQViewModel.isChartInitialized()) {
+          return@Runnable
+        }
         chartIQViewModel.updateCallbacks.find { it.id == id }?.let {
           it.callback.execute(data.toOHCLList())
+          chartIQViewModel.updateCallbacks.removeAll { callback -> callback.id == id }
         }
       })
     }
@@ -66,8 +74,12 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
   fun setPagingData(data: ReadableArray, id: String) {
     if (data != null) {
       handler.post(Runnable {
+        if (!chartIQViewModel.isChartInitialized()) {
+          return@Runnable
+        }
         chartIQViewModel.pagingCallbacks.find { it.id == id }?.let {
           it.callback.execute(data.toOHCLList())
+          chartIQViewModel.pagingCallbacks.removeAll { callback -> callback.id == id }
         }
       })
     }

--- a/android/src/main/java/com/chartiqwrapper/ChartIqWrapperPackage.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIqWrapperPackage.kt
@@ -20,14 +20,41 @@ class ChartIQViewModel {
   var initialCallbacks: MutableList<RNDataSourceCallback> = mutableListOf()
   var updateCallbacks: MutableList<RNDataSourceCallback>  = mutableListOf()
   var pagingCallbacks: MutableList<RNDataSourceCallback>  = mutableListOf()
+  
+  private var isActive: Boolean = true
 
   fun setChartIQ(input: ChartIQ): ChartIQ {
     chartIQ = input
+    isActive = true
     return chartIQ
   }
 
   fun getChartIQ(): ChartIQ {
     return chartIQ
+  }
+  
+  fun isViewActive(): Boolean {
+    return isActive && this::chartIQ.isInitialized
+  }
+  
+  fun isChartInitialized(): Boolean {
+    return this::chartIQ.isInitialized
+  }
+  
+  fun completeAndClearAllCallbacks() {
+    synchronized(this) {
+      val emptyList = emptyList<com.chartiq.sdk.model.OHLCParams>()
+      
+      initialCallbacks.forEach { it.callback.execute(emptyList) }
+      updateCallbacks.forEach { it.callback.execute(emptyList) }
+      pagingCallbacks.forEach { it.callback.execute(emptyList) }
+      
+      initialCallbacks.clear()
+      updateCallbacks.clear()
+      pagingCallbacks.clear()
+      
+      isActive = false
+    }
   }
 
 }

--- a/android/src/main/java/com/chartiqwrapper/ChartIqWrapperViewManager.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIqWrapperViewManager.kt
@@ -228,6 +228,11 @@ class ChartIqWrapperViewManager(private val chartIQViewModel: ChartIQViewModel) 
           params: QuoteFeedParams,
           callback: DataSourceCallback,
         ) {
+          // Only block if chart is not initialized, not during normal operation
+          if (!chartIQViewModel.isChartInitialized()) {
+            callback.execute(emptyList())
+            return
+          }
           chartIQViewModel.initialCallbacks.add(RNDataSourceCallback(callback, params.callbackId!!))
           dispatchOnPullInitialData(params, params.callbackId!!)
         }
@@ -236,6 +241,11 @@ class ChartIqWrapperViewManager(private val chartIQViewModel: ChartIQViewModel) 
           params: QuoteFeedParams,
           callback: DataSourceCallback,
         ) {
+          // Only block if chart is not initialized, not during normal operation
+          if (!chartIQViewModel.isChartInitialized()) {
+            callback.execute(emptyList())
+            return
+          }
           chartIQViewModel.updateCallbacks.add(RNDataSourceCallback(callback, params.callbackId!!))
           dispatchOnPullUpdateData(params, params.callbackId!!)
         }
@@ -244,6 +254,11 @@ class ChartIqWrapperViewManager(private val chartIQViewModel: ChartIQViewModel) 
           params: QuoteFeedParams,
           callback: DataSourceCallback,
         ) {
+          // Only block if chart is not initialized, not during normal operation
+          if (!chartIQViewModel.isChartInitialized()) {
+            callback.execute(emptyList())
+            return
+          }
           chartIQViewModel.pagingCallbacks.add(RNDataSourceCallback(callback, params.callbackId!!))
           dispatchOnPullPagingData(params, params.callbackId!!)
         }

--- a/example/src/navigation/root.navigator.tsx
+++ b/example/src/navigation/root.navigator.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
 import { MainScreen } from '~/screens/root';
+import { TestRigScreen } from '~/screens/test-rig';
 import { RootStack, RootStackParamList } from '~/shared/navigation.types';
 
 import { DrawingsStackNavigator } from './drawings';
@@ -12,8 +13,11 @@ import { StudiesStackNavigator } from './studies';
 const { Navigator, Screen } = createNativeStackNavigator<RootStackParamList>();
 
 const RootNavigator: React.FC = () => {
+  // Flag to start app in Test Rig screen
+  const shouldStartInTestRig = true;
+
   return (
-    <Navigator>
+    <Navigator initialRouteName={shouldStartInTestRig ? RootStack.TestRig : RootStack.Main}>
       <Screen options={{ headerShown: false }} name={RootStack.Main} component={MainScreen} />
       <Screen
         options={{ headerShown: false }}
@@ -34,6 +38,11 @@ const RootNavigator: React.FC = () => {
         options={{ headerShown: false }}
         name={RootStack.Signals}
         component={SignalsStackNavigator}
+      />
+      <Screen
+        options={{ headerShown: true, headerTitle: 'Test Rig' }}
+        name={RootStack.TestRig}
+        component={TestRigScreen}
       />
     </Navigator>
   );

--- a/example/src/navigation/root.navigator.tsx
+++ b/example/src/navigation/root.navigator.tsx
@@ -14,7 +14,7 @@ const { Navigator, Screen } = createNativeStackNavigator<RootStackParamList>();
 
 const RootNavigator: React.FC = () => {
   // Flag to start app in Test Rig screen
-  const shouldStartInTestRig = true;
+  const shouldStartInTestRig = false;
 
   return (
     <Navigator initialRouteName={shouldStartInTestRig ? RootStack.TestRig : RootStack.Main}>

--- a/example/src/screens/root/root.screen.tsx
+++ b/example/src/screens/root/root.screen.tsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { ChartIQ, ChartIQLanguages, ChartIQView } from 'react-native-chartiq';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { WEB_VIEW_SOURCE } from '~/constants';
 import { asyncStorageKeys } from '~/constants/async-storage-keys';
+import { RootStack } from '~/shared/navigation.types';
 import { useChartIQ } from '~/shared/hooks/use-chart-iq';
 import { usePullData } from '~/shared/hooks/use-pull-data';
 import { useTranslations } from '~/shared/hooks/use-translations';
@@ -24,6 +26,8 @@ import SymbolSelector from '~/ui/symbol-selector/symbol-selector.component';
 export default function Root() {
   const theme = useTheme();
   const styles = createStyles(theme);
+  const navigation = useNavigation();
+  const route = useRoute();
 
   const symbolSelectorRef = React.useRef<BottomSheetMethods>(null);
   const intervalSelectorRef = React.useRef<BottomSheetMethods>(null);
@@ -82,6 +86,9 @@ export default function Root() {
 
   const displayStyle: ViewStyle = { display: isFullscreen ? 'none' : 'flex' };
 
+  // coming from Test Rig Screen ?
+  const showBackButton = route.name === RootStack.Main && navigation.canGoBack();
+
   const get = React.useCallback(async () => {
     let userLanguage =
       (await AsyncStorage.getItem(asyncStorageKeys.languageCode)) ?? ChartIQLanguages.EN.code;
@@ -113,6 +120,7 @@ export default function Root() {
           isDrawing={isDrawing}
           isLandscape={isLandscape}
           loading={!initialized}
+          showBackButton={showBackButton}
         />
       </View>
       <View style={styles.chartContainer}>

--- a/example/src/screens/root/root.screen.tsx
+++ b/example/src/screens/root/root.screen.tsx
@@ -1,16 +1,16 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import * as React from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { ChartIQ, ChartIQLanguages, ChartIQView } from 'react-native-chartiq';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { WEB_VIEW_SOURCE } from '~/constants';
 import { asyncStorageKeys } from '~/constants/async-storage-keys';
-import { RootStack } from '~/shared/navigation.types';
 import { useChartIQ } from '~/shared/hooks/use-chart-iq';
 import { usePullData } from '~/shared/hooks/use-pull-data';
 import { useTranslations } from '~/shared/hooks/use-translations';
+import { RootStack } from '~/shared/navigation.types';
 import { Theme, useTheme } from '~/theme';
 import { BottomSheetMethods } from '~/ui/bottom-sheet';
 import { ChartStyleSelector } from '~/ui/chart-style-selector';

--- a/example/src/screens/test-rig/index.ts
+++ b/example/src/screens/test-rig/index.ts
@@ -1,0 +1,1 @@
+export { default as TestRigScreen } from './test-rig.screen';

--- a/example/src/screens/test-rig/test-rig.screen.tsx
+++ b/example/src/screens/test-rig/test-rig.screen.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+
+import { RootStack } from '~/shared/navigation.types';
+import { useTheme } from '~/theme';
+
+const TestRig: React.FC = () => {
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  const navigation = useNavigation();
+
+  const handleOpenChart = () => {
+    navigation.navigate(RootStack.Main as never);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Test Rig</Text>
+        <Text style={styles.description}>
+          You can open the chart from here. The chart has a back button to return to this screen.
+        </Text>
+
+        <TouchableOpacity style={styles.button} onPress={handleOpenChart}>
+          <Text style={styles.buttonText}>Open Chart</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: 'bold',
+      color: theme.colors.buttonText,
+      marginBottom: 16,
+    },
+    description: {
+      fontSize: 16,
+      color: theme.colors.buttonText,
+      textAlign: 'center',
+      marginBottom: 32,
+    },
+    button: {
+      backgroundColor: theme.colors.colorPrimary,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      borderRadius: 8,
+    },
+    buttonText: {
+      color: theme.colors.background,
+      fontSize: 16,
+      fontWeight: '600',
+    },
+  });
+
+export default TestRig;

--- a/example/src/shared/navigation.types.ts
+++ b/example/src/shared/navigation.types.ts
@@ -15,6 +15,7 @@ export enum RootStack {
   Settings = '[Root stack] Settings',
   Drawings = '[Root stack] Drawings',
   Signals = '[Root stack] Signals',
+  TestRig = '[Root stack] TestRig',
 }
 
 export type RootStackParamList = {
@@ -23,6 +24,7 @@ export type RootStackParamList = {
   [RootStack.Settings]: undefined;
   [RootStack.Studies]: undefined;
   [RootStack.Signals]: undefined;
+  [RootStack.TestRig]: undefined;
 };
 
 export enum DrawingsStack {

--- a/example/src/ui/header/header.component.tsx
+++ b/example/src/ui/header/header.component.tsx
@@ -40,6 +40,7 @@ const Header: React.FC<HeaderProps> = ({
   isDrawing,
   isLandscape,
   loading,
+  showBackButton = false,
 }) => {
   const theme = useTheme();
   const styles = createStyles(theme);
@@ -75,6 +76,10 @@ const Header: React.FC<HeaderProps> = ({
 
     runOnJS(setOpen)((prevState) => !prevState);
   }, [open, otherToolsHeight]);
+
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   useEffect(() => {
     if (open && isLandscape) {
@@ -278,6 +283,16 @@ const Header: React.FC<HeaderProps> = ({
     <>
       <Animated.View style={[styles.container]}>
         <View style={styles.row}>
+          {showBackButton && (
+            <TouchableOpacity onPress={handleBack} style={styles.backButton}>
+              <Icons.chevronRight
+                style={styles.backIcon}
+                fill={theme.colors.buttonText}
+                width={20}
+                height={20}
+              />
+            </TouchableOpacity>
+          )}
           <TouchableOpacity onPress={handleSymbolSelector} style={styles.button}>
             {symbol && !loading ? (
               <Text numberOfLines={1} ellipsizeMode="middle" style={styles.buttonText}>

--- a/example/src/ui/header/header.styles.ts
+++ b/example/src/ui/header/header.styles.ts
@@ -24,6 +24,23 @@ export const createStyles = (theme: Theme) =>
       flexDirection: 'row',
       justifyContent: 'space-between',
     },
+    backButton: {
+      backgroundColor: theme.colors.buttonBackground,
+      height: 32,
+      width: 32,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 16,
+      marginRight: 8,
+    },
+    backButtonText: {
+      color: theme.colors.buttonText,
+      fontSize: 18,
+      fontWeight: 'bold',
+    },
+    backIcon: {
+      transform: [{ scaleX: -1 }], // Flip horizontally to point left
+    },
     button: {
       backgroundColor: theme.colors.buttonBackground,
       height: 32,

--- a/example/src/ui/header/header.types.ts
+++ b/example/src/ui/header/header.types.ts
@@ -30,4 +30,5 @@ export interface HeaderProps {
   isDrawing: boolean;
   isLandscape: boolean;
   loading: boolean;
+  showBackButton?: boolean;
 }

--- a/ios/ChartIQDelegate.swift
+++ b/ios/ChartIQDelegate.swift
@@ -68,4 +68,25 @@ class ChartIQHelper: NSObject {
         }
         return array
     }
+    
+    func completeAndClearAllCallbacks() {
+        defaultQueue.async {
+            let emptyData: [ChartIQData] = []
+            
+            self.onPullInitialCompleationHandlers.forEach { callback in
+                callback.callback(emptyData)
+            }
+            self.onPullInitialCompleationHandlers.removeAll()
+            
+            self.onPullUpdateCompleationHandlers.forEach { callback in
+                callback.callback(emptyData)
+            }
+            self.onPullUpdateCompleationHandlers.removeAll()
+            
+            self.onPullPagingCompleationHandlers.forEach { callback in
+                callback.callback(emptyData)
+            }
+            self.onPullPagingCompleationHandlers.removeAll()
+        }
+    }
 }

--- a/ios/ChartIQView.swift
+++ b/ios/ChartIQView.swift
@@ -12,12 +12,14 @@ class ChartIqWrapperView: UIView {
 
     @objc var url: String = "" {
         didSet {
+            guard let chartIQView = chartIQView else { return }
             chartIQView.setChartIQUrl(url)
         }
     }
     
     @objc var dataMethod: String = "pull" {
         didSet {
+            guard let chartIQView = chartIQView else { return }
             chartIQView.setDataMethod(dataMethod == "push" ? .push : .pull)
         }
     }
@@ -55,7 +57,8 @@ class ChartIqWrapperView: UIView {
 extension ChartIqWrapperView: ChartIQDataSource {
     func pullInitialData(by params: ChartIQ.ChartIQQuoteFeedParams, completionHandler: @escaping ([ChartIQ.ChartIQData]) -> Void) {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
-            if(self.chartIQHelper == nil){
+            if self.chartIQHelper == nil || self.chartIQView == nil || self.superview == nil {
+                completionHandler([])
                 return
             }
             let id = UUID().uuidString
@@ -66,7 +69,8 @@ extension ChartIqWrapperView: ChartIQDataSource {
     
     func pullUpdateData(by params: ChartIQ.ChartIQQuoteFeedParams, completionHandler: @escaping ([ChartIQ.ChartIQData]) -> Void) {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
-            if(self.chartIQHelper == nil){
+            if self.chartIQHelper == nil || self.chartIQView == nil || self.superview == nil {
+                completionHandler([])
                 return
             }
             let id = UUID().uuidString
@@ -77,7 +81,8 @@ extension ChartIqWrapperView: ChartIQDataSource {
     
     func pullPaginationData(by params: ChartIQ.ChartIQQuoteFeedParams, completionHandler: @escaping ([ChartIQ.ChartIQData]) -> Void) {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0) {
-            if(self.chartIQHelper == nil){
+            if self.chartIQHelper == nil || self.chartIQView == nil || self.superview == nil {
+                completionHandler([])
                 return
             }
             let id = UUID().uuidString
@@ -100,6 +105,7 @@ extension ChartIqWrapperView: ChartIQDataSource {
 
 extension ChartIqWrapperView: RCTInvalidating {
     func invalidate() {
+        chartIQHelper?.completeAndClearAllCallbacks()
         chartIQHelper = nil
         chartIQView = nil
         chartIQDatasource = nil


### PR DESCRIPTION
Resolves https://chartiq.kanbanize.com/ctrl_board/15/cards/53000/details/

RCA: App was crashing when users navigated away from the chart. The chart view got destroyed but async callbacks kept running with invalid references.

Solution: Added safety checks so callbacks gracefully handle destroyed views instead of crashing. Applied the fix to both iOS (where the issue was happening) and Android (as prevention).

Testing: Added a Test Rig screen with a `shouldStartInTestRig` flag in root navigator (`example/src/navigation/root.navigator.tsx`). When set to true(defaults to false), app opens directly to Test Rig instead of main chart, making it easy to test navigation scenarios and validate the crash fix. You will see back button only if you are navigating from test-rig screen
