### PR TITLE
55501 add push methods

### DIFF
--- a/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
@@ -86,8 +86,25 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
   }
 
   @ReactMethod
-  fun setPeriodicity(period: Int, interval: String, timeUnit: String) {
+  fun push(symbol: String, data: ReadableArray) {
+  	if (data != null) {
+ 		handler.post(Runnable {
+      		chartIQViewModel.getChartIQ().push(symbol, data.toOHCLList())
+    	})
+  	}
+  }
 
+  @ReactMethod
+  fun pushUpdate(data: ReadableArray, useAsLastSale: Boolean) {
+  	if (data != null) {
+ 		handler.post(Runnable {
+      		chartIQViewModel.getChartIQ().pushUpdate(data.toOHCLList(), useAsLastSale)
+    	})
+  	}
+  }
+
+  @ReactMethod
+  fun setPeriodicity(period: Int, interval: String, timeUnit: String) {
     handler.post(Runnable {
       chartIQViewModel.getChartIQ().setPeriodicity(period, interval, TimeUnit.valueOf(timeUnit))
     })

--- a/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
@@ -95,12 +95,30 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
   }
 
   @ReactMethod
+  fun pushJson(symbol: String, data: String) {
+    if (data != null) {
+      handler.post(Runnable {
+        chartIQViewModel.getChartIQ().push(symbol, data)
+      })
+    }
+  }
+
+  @ReactMethod
   fun pushUpdate(data: ReadableArray, useAsLastSale: Boolean) {
   	if (data != null) {
  		handler.post(Runnable {
       		chartIQViewModel.getChartIQ().pushUpdate(data.toOHCLList(), useAsLastSale)
     	})
   	}
+  }
+
+  @ReactMethod
+  fun pushJsonUpdate(data: String, useAsLastSale: Boolean) {
+    if (data != null) {
+      handler.post(Runnable {
+        chartIQViewModel.getChartIQ().pushUpdate(data, useAsLastSale)
+      })
+    }
   }
 
   @ReactMethod

--- a/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
+++ b/android/src/main/java/com/chartiqwrapper/ChartIQWrapperModule.kt
@@ -98,7 +98,7 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
   fun pushJson(symbol: String, data: String) {
     if (data != null) {
       handler.post(Runnable {
-        chartIQViewModel.getChartIQ().push(symbol, data)
+      		chartIQViewModel.getChartIQ().push(symbol, data)
       })
     }
   }
@@ -116,7 +116,7 @@ class ChartIQWrapperModule(private val chartIQViewModel: ChartIQViewModel) :
   fun pushJsonUpdate(data: String, useAsLastSale: Boolean) {
     if (data != null) {
       handler.post(Runnable {
-        chartIQViewModel.getChartIQ().pushUpdate(data, useAsLastSale)
+      		chartIQViewModel.getChartIQ().pushUpdate(data, useAsLastSale)
       })
     }
   }

--- a/ios/ChartIqWrapperViewManager.m
+++ b/ios/ChartIqWrapperViewManager.m
@@ -13,6 +13,11 @@ RCT_EXTERN_METHOD(setInitialData:(NSArray *)data id:(NSString *)id)
 RCT_EXTERN_METHOD(setUpdateData:(NSArray *)data id:(NSString *)id)
 RCT_EXTERN_METHOD(setPagingData:(NSArray *)data id:(NSString *)id)
 
+RCT_EXTERN_METHOD(push:(NSString *)symbol data:(NSArray *)data)
+RCT_EXTERN_METHOD(pushJson:(NSString *)symbol data:(NSString *)data)
+RCT_EXTERN_METHOD(pushUpdate:(NSArray *)data useAsLastSale:(BOOL)useAsLastSale)
+RCT_EXTERN_METHOD(pushJsonUpdate:(NSString *)data useAsLastSale:(BOOL)useAsLastSale)
+
 RCT_EXTERN_METHOD(setPeriodicity:(double)period interval:(NSString *)interval timeUnit:(NSString *)timeUnit)
 RCT_EXTERN_METHOD(setChartStyle:(NSString *)obj attr:(NSString *)attr value:(NSString *)value)
 RCT_EXTERN_METHOD(setChartType:(NSString *)type)

--- a/ios/ChartIqWrapperViewManager.m
+++ b/ios/ChartIqWrapperViewManager.m
@@ -14,9 +14,9 @@ RCT_EXTERN_METHOD(setUpdateData:(NSArray *)data id:(NSString *)id)
 RCT_EXTERN_METHOD(setPagingData:(NSArray *)data id:(NSString *)id)
 
 RCT_EXTERN_METHOD(push:(NSString *)symbol data:(NSArray *)data)
-RCT_EXTERN_METHOD(pushJson:(NSString *)symbol data:(NSString *)data)
+RCT_EXTERN_METHOD(pushJson:(NSString *)symbol jsonData:(NSString *)jsonData)
 RCT_EXTERN_METHOD(pushUpdate:(NSArray *)data useAsLastSale:(BOOL)useAsLastSale)
-RCT_EXTERN_METHOD(pushJsonUpdate:(NSString *)data useAsLastSale:(BOOL)useAsLastSale)
+RCT_EXTERN_METHOD(pushJsonUpdate:(NSString *)jsonData useAsLastSale:(BOOL)useAsLastSale)
 
 RCT_EXTERN_METHOD(setPeriodicity:(double)period interval:(NSString *)interval timeUnit:(NSString *)timeUnit)
 RCT_EXTERN_METHOD(setChartStyle:(NSString *)obj attr:(NSString *)attr value:(NSString *)value)

--- a/ios/ChartIqWrapperViewManager.swift
+++ b/ios/ChartIqWrapperViewManager.swift
@@ -53,6 +53,44 @@ class ChartIqWrapperViewManager: RCTViewManager {
             self.chartIQHelper.updatePagingData(data: data, id: id)
         }
     }
+  
+    @objc func push(_ symbol: String, data: [[String: Any]]) {
+        defaultQueue.async {
+          var array: [ChartIQData] = []
+                  data.forEach { item in
+                      let quote = ChartIQData.init(dictionary: item)
+                      array.append(quote)
+                  }
+          guard let chartIQView = self.chartIQWrapperView?.chartIQView else { return }
+          chartIQView.push(symbol, data: array)
+        }
+    }
+  
+    @objc func pushJson(_ symbol: String, jsonData: String) {
+        defaultQueue.async {
+        guard let chartIQView = self.chartIQWrapperView?.chartIQView else { return }
+          chartIQView.push(symbol, jsonString: jsonData)
+      }
+    }
+  
+    @objc func pushUpdate(_ data: [[String: Any]], useAsLastSale: Bool) {
+        defaultQueue.async {
+          var array: [ChartIQData] = []
+                  data.forEach { item in
+                      let quote = ChartIQData.init(dictionary: item)
+                      array.append(quote)
+                  }
+          guard let chartIQView = self.chartIQWrapperView?.chartIQView else { return }
+          chartIQView.pushUpdate(array, useAsLastSale: useAsLastSale)
+        }
+    }
+  
+    @objc func pushJsonUpdate(_ jsonData: String, useAsLastSale: Bool) {
+        defaultQueue.async {
+          guard let chartIQView = self.chartIQWrapperView?.chartIQView else { return }
+          chartIQView.pushUpdate(jsonData, useAsLastSale: useAsLastSale)
+        }
+    }
     
     @objc func setPeriodicity(_ period: Double, interval: String, timeUnit: String) {
         defaultQueue.async {
@@ -383,6 +421,7 @@ class ChartIqWrapperViewManager: RCTViewManager {
     }
     
     @objc func enableCrosshairs() {
+        print("Hello, world!")
         defaultQueue.async {
             self.chartIQWrapperView.chartIQView.enableCrosshairs(true)
         }

--- a/ios/ChartIqWrapperViewManager.swift
+++ b/ios/ChartIqWrapperViewManager.swift
@@ -421,7 +421,6 @@ class ChartIqWrapperViewManager: RCTViewManager {
     }
     
     @objc func enableCrosshairs() {
-        print("Hello, world!")
         defaultQueue.async {
             self.chartIQWrapperView.chartIQView.enableCrosshairs(true)
         }

--- a/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
+++ b/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
@@ -71,23 +71,55 @@ export function setUpdateData(data: OHLCParams[], id: string) {
  * @returns void
  * @example
  * ChartIQ.setPagingData(data, id)
- *   **/
+ */
 export function setPagingData(data: OHLCParams[], id: string) {
   ChartIQWrapperModule.setPagingData(data, id);
 }
 
+/**
+ * Sets the chart data with OHLC array by push.
+ * @param {string} symbol
+ * @param {OHLCParams[]} data
+ * @returns void
+ * @example
+ * ChartIQ.push(symbol, data)
+ */
 export function push(symbol: string, data: OHLCParams[]) {
   ChartIQWrapperModule.push(symbol, data);
 }
 
+/**
+ * Sets the chart data with JSON by push.
+ * @param {string} symbol
+ * @param {string} jsonData
+ * @returns void
+ * @example
+ * ChartIQ.push(symbol, data)
+ */
 export function pushJson(symbol: string, jsonData: string) {
   ChartIQWrapperModule.push(symbol, jsonData);
 }
 
+/**
+ * Stream OHLC data into a chart.
+ * @param {OHLCParams} data
+ * @param {Boolean} useAsLastSale
+ * @returns void
+ * @example
+ * ChartIQ.pushUpdate(data, useAsLastSale)
+ */
 export function pushUpdate(data: OHLCParams[], useAsLastSale: Boolean) {
   ChartIQWrapperModule.pushUpdate(data, useAsLastSale);
 }
 
+/**
+ * Stream OHLC data into a chart via a JSON object.
+ * @param {string} jsonData
+ * @param {Boolean} useAsLastSale
+ * @returns void
+ * @example
+ * ChartIQ.pushUpdate(data, useAsLastSale)
+ */
 export function pushJsonUpdate(jsonData: string, useAsLastSale: Boolean) {
   ChartIQWrapperModule.pushUpdate(jsonData, useAsLastSale);
 }

--- a/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
+++ b/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
@@ -76,6 +76,22 @@ export function setPagingData(data: OHLCParams[], id: string) {
   ChartIQWrapperModule.setPagingData(data, id);
 }
 
+export function push(symbol: string, data: OHLCParams[]) {
+  ChartIQWrapperModule.push(symbol, data);
+}
+
+export function pushJson(symbol: string, jsonData: string) {
+  ChartIQWrapperModule.push(symbol, jsonData);
+}
+
+export function pushUpdate(data: OHLCParams[], useAsLastSale: Boolean) {
+  ChartIQWrapperModule.pushUpdate(data, useAsLastSale);
+}
+
+export function pushJsonUpdate(jsonData: string, useAsLastSale: Boolean) {
+  ChartIQWrapperModule.pushUpdate(jsonData, useAsLastSale);
+}
+
 /** Set periodicity
  * @param {number} period
  * @param {string} interval

--- a/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
+++ b/src/chart-iq-wrapper-module/chart-iq-wrapper-module.ts
@@ -97,31 +97,31 @@ export function push(symbol: string, data: OHLCParams[]) {
  * ChartIQ.push(symbol, data)
  */
 export function pushJson(symbol: string, jsonData: string) {
-  ChartIQWrapperModule.push(symbol, jsonData);
+  ChartIQWrapperModule.pushJson(symbol, jsonData);
 }
 
 /**
  * Stream OHLC data into a chart.
  * @param {OHLCParams} data
- * @param {Boolean} useAsLastSale
+ * @param {boolean} useAsLastSale
  * @returns void
  * @example
  * ChartIQ.pushUpdate(data, useAsLastSale)
  */
-export function pushUpdate(data: OHLCParams[], useAsLastSale: Boolean) {
+export function pushUpdate(data: OHLCParams[], useAsLastSale: boolean) {
   ChartIQWrapperModule.pushUpdate(data, useAsLastSale);
 }
 
 /**
  * Stream OHLC data into a chart via a JSON object.
  * @param {string} jsonData
- * @param {Boolean} useAsLastSale
+ * @param {boolean} useAsLastSale
  * @returns void
  * @example
  * ChartIQ.pushUpdate(data, useAsLastSale)
  */
-export function pushJsonUpdate(jsonData: string, useAsLastSale: Boolean) {
-  ChartIQWrapperModule.pushUpdate(jsonData, useAsLastSale);
+export function pushJsonUpdate(jsonData: string, useAsLastSale: boolean) {
+  ChartIQWrapperModule.pushJsonUpdate(jsonData, useAsLastSale);
 }
 
 /** Set periodicity


### PR DESCRIPTION
Re-implement the push methods for the React Native application. 

You can replace the ChartIQView component in the **example/src/screens/root.screen.tsx** file, or just replace the entire file with the same named file attached in the ticket. The push methods are ready for testing in the component below.

A future ticket will be created to take are of the issue where onPullInitialData still needs to be defined for a push based application. In the meantime this workaround does the trick.

```
<ChartIQView
          url={WEB_VIEW_SOURCE}
          dataMethod="push"
          onStart={initChart}
          onPullInitialData={async ({ nativeEvent }) => {
            // Called when chart needs initial data
            const { id } = nativeEvent.quoteFeedParam

            let newQuotes: OHLCParams[] = [];
            let newQuote: OHLCParams = {
              DT: '2026-03-23T16:00:00.000Z',
              Open: 155,
              High: 160,
              Low: 145,
              Close: 150,
              Volume: 202222,
            };
            newQuotes.push(newQuote);

            ChartIQ.setInitialData([], id);
            ChartIQ.push('IBM', newQuotes);
            //ChartIQ.pushJson('IBM', JSON.stringify(newQuotes));

            let updateQuotes: OHLCParams[] = [];
            let updateQuote: OHLCParams = {
              DT: '2026-03-24T16:00:00.000Z',
              Open: 150,
              High: 157,
              Low: 147,
              Close: 155,
              Volume: 202222,
            };
            updateQuotes.push(updateQuote);
            ChartIQ.pushUpdate(updateQuotes, false);
            //ChartIQ.pushJsonUpdate(JSON.stringify(updateQuotes), false);
          }}
          //onPullUpdateData={onPullUpdateData}
          //onPullPagingData={onPullPagingData}
          onMeasureChanged={() => {
            // console.log("Chart measure changed");
          }}
          style={styles.chartIq}
        />
```